### PR TITLE
fix minor range bug in preserveBlankLines withing a Program block

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -1710,7 +1710,8 @@
 
                     // handle spaces between lines
                     if (i > 0) {
-                        if (!stmt.body[i - 1].trailingComments && !stmt.body[i].leadingComments) {
+                        if (!stmt.body[i - 1].trailingComments && !stmt.body[i].leadingComments &&
+                          stmt.body[i - 1].range && stmt.body[i].range) {
                             generateBlankLines(stmt.body[i - 1].range[1], stmt.body[i].range[0], result);
                         }
                     }


### PR DESCRIPTION
At line 1714, there is a potential bug, if a Program block has a child with no range attached.  This can cause an exception:

```
TypeError: Cannot read property '0' of undefined
    at CodeGenerator.Program (/Volumes/DevPartition/pdev/toolbox/node/m12n/node_modules/escodegen/escodegen.js:1714:93)
    at CodeGenerator.generateStatement (/Volumes/DevPartition/pdev/toolbox/node/m12n/node_modules/escodegen/escodegen.js:2479:33)
    at generateInternal (/Volumes/DevPartition/pdev/toolbox/node/m12n/node_modules/escodegen/escodegen.js:2500:28)
    at Object.generate (/Volumes/DevPartition/pdev/toolbox/node/m12n/node_modules/escodegen/escodegen.js:2569:18)
    at Translator.write (/Volumes/DevPartition/pdev/toolbox/node/m12n/src/translator.js:98:24)
    at DestroyableTransform._transform (/Volumes/DevPartition/pdev/toolbox/node/m12n/src/translator.js:417:23)
    at DestroyableTransform.Transform._read (/Volumes/DevPartition/pdev/toolbox/node/m12n/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:159:10)

```

This fix simply checks for the existence of a range.
